### PR TITLE
Restore BUILD_IDA variable 

### DIFF
--- a/src/allmake.mak
+++ b/src/allmake.mak
@@ -824,6 +824,10 @@ module_dll=$(BIN_PATH)$(1)$(SUFF32)$(DLLEXT)
 # output name for server executable
 server_exe=$(R)dbgsrv/$(1)
 
+ifeq ($(or $(M),$(MM),$(MMH),$(MO),$(MMO),$(MMHO)),1)
+  BUILD_IDA = 1
+endif
+
 BUILD_DBGSRV-$(__NT__)-$(or $(MSO),$(M32X86SO)) = 1
 BUILD_DBGSRV-$(__UNIX__)-$(or $(M),$(MO),$(M32X86),$(M32X86O)) = 1
 ifdef BUILD_DBGSRV-1-1


### PR DESCRIPTION
Restore `BUILD_IDA` var in `ida-sdk/src/allmake.mak` file.

Its absence causes the ida-sdk/src/makefile file to only take into account the dbg folder:
```
ifdef BUILD_IDA
  ALLDIRS += ldr
  ALLDIRS += module
  ALLDIRS += plugins
  ALLDIRS += idalib/examples
endif
ALLDIRS += dbg
```