### PR TITLE
Add Build workflow

### DIFF
--- a/.github/workflows/Build_Release.yml
+++ b/.github/workflows/Build_Release.yml
@@ -1,0 +1,208 @@
+name: Build & Release
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (v1.0)"
+        required: true
+      name:
+        description: "Release name (optional)"
+        required: false
+  
+  push:
+    branches: [ main ]
+    
+  pull_request:
+    branches: [ main ]
+    
+  release:              # triggered when a release is created
+    types: [published]
+
+
+
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            os_display: ubuntu
+          - os: windows-latest
+            os_display: windows
+          - os: macos-latest
+            os_display: macos
+
+    outputs:
+      tag: ${{ steps.meta.outputs._tag }}
+      name: ${{ steps.meta.outputs._name }}
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+
+      # outputing tag and name
+      - name: Set release metadata
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "_tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "_name=${{ github.event.release.name }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "_tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "_name=${{ github.event.inputs.name || github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "No release will be created"
+          fi
+
+      
+      # --------------------
+      # Prerequisites
+      # --------------------
+      - name: Install prerequisites (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc g++ make clang doxygen graphviz
+        shell: bash
+
+      - name: Install prerequisites (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew install llvm doxygen graphviz
+        shell: bash
+
+      - name: Install prerequisites (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install -y visualstudio2022buildtools visualstudio2022-workload-vctools doxygen.install graphviz
+          echo "C:\Program Files\doxygen\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files\Graphviz\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+
+      # --------------------
+      # Build documentation
+      # --------------------
+      - name: Build documentation (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          if [ -d docs ]; then
+            cd docs
+            doxygen Doxyfile
+          else
+            echo "no docs directory"
+          fi
+        shell: bash
+
+      - name: Build documentation (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          if (Test-Path docs) {
+            Push-Location docs
+            doxygen Doxyfile
+            Pop-Location
+          } else {
+            Write-Host "no docs directory"
+          }
+        shell: powershell
+
+      # --------------------
+      # Build the SDK
+      # --------------------
+      - name: Build (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd src
+          make -j$(nproc)
+        shell: bash
+
+      - name: Build (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          cd src
+          JOBS=$(sysctl -n hw.ncpu || echo 2)
+          make -j${JOBS}
+        shell: bash
+
+      - name: Build (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          :: Locate VS install
+          for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSPath=%%i
+          call "%VSPath%\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cd src
+          bin\mo.bat
+        shell: cmd
+
+      # --------------------
+      # Collect & upload artifacts
+      # --------------------
+      - name: Upload built binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ida-sdk-bin-${{ matrix.os_display }}
+          path: src/bin/**
+
+      - name: Upload whole src dir + bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: ida-sdk-${{ matrix.os_display }}
+          path: src/**
+
+      - name: Upload docs (if produced)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ida-sdk-docs-${{ matrix.os_display }}
+          path: docs/build/**
+
+
+  # --------------------
+  # Create Release
+  # --------------------
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist   # always create ./dist
+
+      - name: Zip artifacts
+        run: |
+          if [ -d dist ]; then
+            cd dist
+            for dir in ida-sdk-bin-*; do
+              if [ -d "$dir" ]; then
+                zip -r "${dir}.zip" "$dir"
+              fi
+            done
+
+            for dir in ida-sdk-docs-*; do
+              if [ -d "$dir" ]; then
+                zip -r "${dir}.zip" "$dir"
+              fi
+            done
+          else
+            echo "No artifacts to package"
+          fi
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.build.outputs.tag }}   # get tag and name
+          name: ${{ needs.build.outputs.name }}
+          files: dist/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow Builds the IDA SDK for Linux, macOS and Windows. 
Both `src` and `src/bin` folders will be uploaded as artifacts and then published as release.
The build procedure for Windows is slow and might have room for optimizations.